### PR TITLE
Fix incompatible declaration

### DIFF
--- a/src/Provider.php
+++ b/src/Provider.php
@@ -66,7 +66,7 @@ class Provider extends AbstractProvider implements ProviderInterface
     /**
      * {@inheritdoc}
      */
-    protected function getCodeFields($state)
+    protected function getCodeFields($state = null)
     {
         $codeFields = parent::getCodeFields($state);
 


### PR DESCRIPTION
Fixes:

`Declaration of SocialiteProviders\Strava\Provider::getCodeFields() should be compatible with Laravel\Socialite\Two\AbstractProvider::getCodeFields($state = NULL)`
